### PR TITLE
Fixing units for unitless numbers

### DIFF
--- a/quantities.js
+++ b/quantities.js
@@ -29,6 +29,8 @@ Numbas.addExtension('quantities',['math','jme','jme-display','js-quantities'],fu
      *  so instead, assume that digits never appear in the names of units, and apply this regex
      */
     function fix_units(units) {
+        if (! units) {return ""};
+
         var m = /([^\/]+)(?:\/(.*))?/.exec(units);
         function fix_prod(units) {
             var bits = units.split('*').map(function(b) {


### PR DESCRIPTION
If two quantities of the same type are divided we get a dimensionless quantity. This causes there to be nothing to match in the fix_unit function.

By checking for a false-like input we can avoid trying this.